### PR TITLE
Add .env.example files for easier setup

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,2 +1,10 @@
 # Client environment variables
-VITE_API_BASE_URL=http://localhost:5000
+
+# Backend API
+VITE_API_URL=http://localhost:3001/api
+
+# WebSocket server
+VITE_SOCKET_URL=http://localhost:3001
+
+# Python backend API
+VITE_PYTHON_API_URL=http://localhost:8000

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,5 +1,47 @@
-# Server environment variables
-
+# Database
 DATABASE_URL=your_mongodb_connection_string
-JWT_SECRET=your_secret_here
-GROQ_API_KEY=get_from_console.groq.com
+
+# JWT
+JWT_SECRET=your_super_secret_jwt_key_here
+
+# Email Configuration (Gmail)
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USER=your-email@gmail.com
+SMTP_PASS=your-app-password
+FROM_EMAIL=your-email@gmail.com
+FROM_NAME=Edulume
+
+# OTP Configuration
+OTP_MODE=development
+
+# File Storage (R2 / Cloudinary / ImgBB)
+R2_ACCOUNT_ID=your_r2_account_id
+R2_ACCESS_KEY_ID=your_r2_access_key
+R2_SECRET_ACCESS_KEY=your_r2_secret_key
+R2_UPLOAD_URL_ID=your_r2_upload_url_id
+IMGBB_API_KEY=your_imgbb_api_key
+
+# Server Port
+PORT=3001
+
+# Client Configuration
+CLIENT_ORIGIN=http://localhost:5173
+CLIENT_URL=http://localhost:5173
+
+# AI / ML Services
+GROQ_API_KEY=your_groq_api_key
+
+# Admin Configuration
+ADMIN_EMAILS=admin@example.com
+
+# Python Backend
+PYTHON_API_URL=http://localhost:8000
+
+# Redis (Optional)
+REDIS_URL=redis://default:password@host:port
+
+# Google OAuth
+GOOGLE_CLIENT_ID=your_google_client_id.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=your_google_client_secret
+GOOGLE_CALLBACK_URL=http://localhost:3001/api/auth/google/callback


### PR DESCRIPTION
This PR adds `.env.example` files to help new contributors understand
the required environment variables.

- Added client/.env.example
- Added server/.env.example
- Verified python-backend/.env.example

Closes #16
