### PR TITLE
feat:estimated reading time added

### DIFF
--- a/client/src/components/courses/CourseDetailPage.tsx
+++ b/client/src/components/courses/CourseDetailPage.tsx
@@ -559,6 +559,14 @@ const CourseDetailPage: React.FC = () => {
     });
   };
 
+  //Extimated Reading Time function
+  const getReadingTime = (content?: string) => {
+    if (!content) return null;
+    const words = content.trim().split(/\s+/).length;
+    const minutes = Math.ceil(words / 200);
+    return `${minutes} min read`;
+  };
+
   // Fix the ownership check - isAuth is boolean, not user object
   const [currentUser, setCurrentUser] = useState<any>(null);
 
@@ -1200,6 +1208,13 @@ const CourseDetailPage: React.FC = () => {
                         <div className="border-t border-smoke-light p-3 sm:p-4 bg-royal-black/30">
                           {chapter.content ? (
                             <div className="space-y-3 sm:space-y-4">
+                              
+                            {/* Estimated Reading time  */}
+                              <div className="flex items-center text-xs text-gray-400 space-x-1">
+                                <Clock size={12} />
+                                <span>{getReadingTime(chapter.content)}</span>
+                              </div>
+
                               {/* Progress Button for Enrolled Users */}
                               {isAuth && course.is_enrolled && (
                                 <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-3 sm:mb-4 p-3 bg-smoke-gray rounded-lg">


### PR DESCRIPTION
Description:

Adds an estimated reading time (X min read) for course chapters based on chapter content length.
A helper function getReadingTime(content) calculates word count and estimates reading time (~200 WPM).
The reading time is displayed in the expanded chapter view, giving learners a clear idea of how long a chapter will take to read.
This change is frontend-only and does not affect backend APIs.

🔗 Related Issue
Closes #12 

🏷️ Type of Change

[] 🐛 Bug fix (non-breaking change that fixes an issue)
[✓] ✨ New feature (non-breaking change that adds functionality)
[ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
[ ] 📝 Documentation update
[ ] 🎨 Style/UI update
[ ] ♻️ Code refactoring
[ ] ⚡ Performance improvement
[ ] 🧪 Test update

✅ Checklist

[✓] My code follows the project's style guidelines
[✓] I have performed a self-review of my code
[✓] I have commented my code, particularly in hard-to-understand areas
[  ] I have made corresponding changes to the documentation
[✓] My changes generate no new warnings
[✓] I have tested my changes locally
[✓] Any dependent changes have been merged and published

🧪 Testing

[✓] Tested on Chrome
[✓] Tested on Firefox
[✓] Tested on mobile
[ ] Tested API endpoints (if applicable)

📋 Additional Notes
Reading time is shown only when chapter content exists
Uses simple string manipulation and math for performance
No backend or database changes required

SWOC 2026 participant — please add the swoc2026 label to this PR

