### PR TITLE
Enabled chat history fallback when vector retrieval is empty

### DIFF
--- a/python-backend/RAGresponse/RAG_app.py
+++ b/python-backend/RAGresponse/RAG_app.py
@@ -184,9 +184,14 @@ def main(query, chat_history, session_id=None):
         # Retrieve FRESH context for THIS specific query
         content_list = pinecone_retriever(query, session_id)
         
+        # ArnabG: If no documents found, check history before giving up
         if not content_list:
-            logger.warning("No relevant content found in vector store")
-            return "Sorry! I could not find relevant information in the document to answer your question."
+            if len(chat_history) > 0:
+                logger.info("No documents found, but attempting to answer using chat history context.")
+                content_list = ["(No new context found. Answer based on conversation history if possible.)"]
+            else:
+                logger.warning("No relevant content found in vector store and no chat history")
+                return "Sorry! I could not find relevant information in the document to answer your question."
         
         # Summarize chat history if it gets too long
         if len(chat_history) > 10:


### PR DESCRIPTION
`SWOC 2026` label plz
----
@tarinagarwal 

## 📝 Description

This PR fixes a logic flaw in RAG_app.py where the chatbot would immediately reject user queries if the vector database returned no results, ignoring the conversation history.

Previously, if a user asked a follow-up question (e.g., "How old is he?") that lacked specific keywords found in the document, the retriever would return an empty list, and the bot would return a generic error message.

Now, the system checks if chat_history exists before returning an error. If history exists, the query is passed to the LLM, allowing it to infer context (like resolving pronouns) from previous turns.

## 🔗 Related Issue

Closes #107 

## 🏷️ Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test update

## ✅ Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested my changes locally
- [x] Any dependent changes have been merged and published

## 🧪 Testing

<!-- Describe how you tested your changes -->

- [x] Tested on Chrome
- [ ] Tested on Firefox
- [ ] Tested on mobile
- [ ] Tested API endpoints (if applicable)
---

**SWOC 2026 Participant?** Add `swoc2026` label to your PR! 🎉
