### PR TITLE
ui: establish visual hierarchy between primary and secondary CTAs

### DIFF
--- a/client/src/components/layout/LandingPage.tsx
+++ b/client/src/components/layout/LandingPage.tsx
@@ -450,21 +450,26 @@ const LandingPage: React.FC = () => {
                 courses and community support
               </p>
               <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link
-  to="/courses"
-  className="alien-button text-base sm:text-lg px-8 py-4"
->
-  <GraduationCap className="inline mr-2" size={24} />
-  Start Learning Now
-</Link>
+                              <Link
+                  to="/courses"
+                  className="alien-button text-base sm:text-lg px-8 py-4"
+                >
+                  <GraduationCap className="inline mr-2" size={24} />
+                  Start Learning Now
+                </Link>
+                <Link
+                  to="/auth"
+                  className="text-sm sm:text-base px-6 py-3 border border-alien-green/60 text-alien-green font-medium rounded-lg hover:bg-alien-green/10 transition-all duration-200"
+                >
+                  Create Free Account
+                </Link>
 
-<Link
-  to="/auth"
-  className="text-sm sm:text-base px-5 py-3 border border-alien-green/60 text-alien-green font-medium rounded-lg hover:bg-alien-green/10 transition-all duration-200"
-
->
-  Create Free Account
-</Link>
+                <Link
+                  to="/auth"
+                  className="text-sm sm:text-base px-5 py-3 border border-alien-green/60 text-alien-green font-medium rounded-lg hover:bg-alien-green/10 transition-all duration-200"
+                >
+                  Create Free Account
+                </Link>
 
 
               </div>


### PR DESCRIPTION
# Description

-Improved the visual hierarchy of the CTA section on the homepage.
-Kept "Start Learning Now" as the primary (solid) CTA.
-Styled "Create Free Account" as a secondary outlined button.
-No layout, content, or theme changes were made.
-This establishes a clearer primary and secondary action, improving user decision-making.
# Related Issue
- Closes #127 

# Type of Change

 UI improvement
# Screenshot 
![WhatsApp Image 2026-02-15 at 2 11 48 PM](https://github.com/user-attachments/assets/d60cb47c-57e8-447e-969a-b8105e58aa01)


